### PR TITLE
Fix deprecated Actions command

### DIFF
--- a/src/common.sh
+++ b/src/common.sh
@@ -9,7 +9,7 @@ git_add_doc () {
 
 git_changed () {
   GIT_FILES_CHANGED=`git status --porcelain | grep -E '([MA]\W).+' | wc -l`
-  echo "::set-output name=num_changed::${GIT_FILES_CHANGED}"
+  echo "{num_changed}={${GIT_FILES_CHANGED}}" >> $GITHUB_OUTPUT
 }
 
 git_setup () {


### PR DESCRIPTION
# Description
Github is [deprecating the usage of `set-output`](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

# Changes
- Updated the command to the new compatible version

