### PR TITLE
Mark action as archived to prevent name collission

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: terraform-docs
+name: terraform-docs-archived
 author: Derek Rada
 description: A Github action for generating terraform module documentation using terraform-docs and gomplate.
 inputs:


### PR DESCRIPTION
# Description

we would like to rename [official](https://github.com/marketplace/actions/terraform-docs-gh-actions) terraform-docs GitHub Action to `terraform-docs`. As of now there is a name collision with this archived repository. As such I'd like to rename this one.